### PR TITLE
test: add -short guard to TestConcurrentDataProviderInitialization

### DIFF
--- a/internal/mcp/race_test.go
+++ b/internal/mcp/race_test.go
@@ -323,6 +323,9 @@ func TestConcurrentHelperFunctions(t *testing.T) {
 // TestConcurrentDataProviderInitialization tests the critical sync.Once race condition
 // This is the most important race test - targets real shared state in spot.Client
 func TestConcurrentDataProviderInitialization(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires AWS credentials and real EC2 API calls")
+	}
 	const numGoroutines = 50
 	var wg sync.WaitGroup
 	results := make([]*mcp.CallToolResult, numGoroutines)


### PR DESCRIPTION
## Summary

Adds `testing.Short()` guard to `TestConcurrentDataProviderInitialization` in `internal/mcp/race_test.go`.

## Problem

The test makes real AWS EC2 `DescribeSpotPriceHistory` API calls and times out after 60s when running `go test ./... -short` without AWS credentials.

## Fix

Added guard at the top of the function:
```go
if testing.Short() {
    t.Skip("requires AWS credentials and real EC2 API calls")
}
```

## Testing

- `go test ./... -short` now skips this test cleanly ✅
- Full test run (with AWS credentials) still exercises the race condition ✅

Fixes #12

---
*🤖 Automated response by Marvin • [alexei-led](https://github.com/alexei-led)*