### PR TITLE
fix: suppress gosec false positives blocking all PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@
 
 ```bash
 # macOS with Homebrew
-brew tap alexei-led/spotinfo
-brew install spotinfo
+brew tap alexei-led/tap
+brew install alexei-led/tap/spotinfo
 
 # Linux/Windows: Download from releases
 curl -L https://github.com/alexei-led/spotinfo/releases/latest/download/spotinfo_linux_amd64.tar.gz | tar xz

--- a/cmd/spotinfo/main.go
+++ b/cmd/spotinfo/main.go
@@ -285,7 +285,7 @@ func formatPrice(price float64, live bool) string {
 
 func printAdvicesNumber(advices []spot.Advice, region bool, output io.Writer) {
 	if len(advices) == 1 {
-		fmt.Fprintln(output, advices[0].Savings) //nolint:errcheck
+		fmt.Fprintln(output, advices[0].Savings) //nolint:errcheck,gosec // G602: false positive, length checked above
 		return
 	}
 

--- a/internal/spot/data.go
+++ b/internal/spot/data.go
@@ -50,7 +50,7 @@ func fetchAdvisorData(ctx context.Context) (*advisorData, error) {
 		return loadEmbeddedAdvisorData()
 	}
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec // G704: spotAdvisorJSONURL is a package-level constant, not user input
 	if err != nil {
 		slog.Warn("failed to fetch advisor data from AWS, using embedded data",
 			slog.String("url", spotAdvisorJSONURL),
@@ -60,7 +60,7 @@ func fetchAdvisorData(ctx context.Context) (*advisorData, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		slog.Warn("non-200 response from AWS advisor API, using embedded data",
+		slog.Warn("non-200 response from AWS advisor API, using embedded data", //nolint:gosec // G706: status_code is integer from HTTP response, not user-controlled input
 			slog.Int("status_code", resp.StatusCode))
 		return loadEmbeddedAdvisorData()
 	}
@@ -111,7 +111,7 @@ func fetchPricingData(ctx context.Context, useEmbedded bool) (*rawPriceData, err
 		return loadEmbeddedPricingData()
 	}
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec // G704: spotPriceJSURL is a package-level constant, not user input
 	if err != nil {
 		slog.Warn("failed to fetch pricing data from AWS, using embedded data",
 			slog.String("url", spotPriceJSURL),
@@ -121,7 +121,7 @@ func fetchPricingData(ctx context.Context, useEmbedded bool) (*rawPriceData, err
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		slog.Warn("non-200 response from AWS pricing API, using embedded data",
+		slog.Warn("non-200 response from AWS pricing API, using embedded data", //nolint:gosec // G706: status_code is integer from HTTP response, not user-controlled input
 			slog.Int("status_code", resp.StatusCode))
 		return loadEmbeddedPricingData()
 	}


### PR DESCRIPTION
## Problem

All open PRs (#24, #25, #26) are failing CI because `golangci-lint` with `gosec` reports false positives in the existing codebase:

- `cmd/spotinfo/main.go:288: G602` — slice index out of range (false positive; length is checked above)
- `internal/spot/data.go:53: G704` — SSRF via taint analysis (false positive; URL is a package-level constant, not user input)
- `internal/spot/data.go:63: G706` — Log injection via taint analysis (false positive; logged value is an integer HTTP status code)
- `internal/spot/data.go:114: G704` — same as above, for pricing data
- `internal/spot/data.go:124: G706` — same as above, for pricing data

## Fix

Added `//nolint:gosec` directives with explanatory comments on each affected line. These are confirmed false positives:

1. **G602**: The `advices[0]` access is guarded by `if len(advices) == 1` — gosec doesn't track this invariant.
2. **G704**: Both URLs (`spotAdvisorJSONURL`, `spotPriceJSURL`) are package-level constants pointing to AWS public endpoints — not user-provided input.
3. **G706**: The logged values are `int` (HTTP status code) from a response to our own constant-URL request — no user data flows into the log.

Also includes a README fix: updated Homebrew tap path from `alexei-led/spotinfo` to `alexei-led/tap`.

## Impact

Merging this PR will unblock CI for #24, #25, and #26.

---
*🤖 Automated response by Marvin • [alexei-led](https://github.com/alexei-led)*